### PR TITLE
Update Xamarin.Swift4.targets

### DIFF
--- a/Swift4/Xamarin.Swift4/build/Xamarin.Swift4.targets
+++ b/Swift4/Xamarin.Swift4/build/Xamarin.Swift4.targets
@@ -17,7 +17,9 @@
 
   <Target Name="_CodesignSwift" Condition="'$(Platform)' == 'iPhone'" BeforeTargets="CoreCodesign">
     <ItemGroup>
-        <_SwiftLibsDevice Include="$(_AppBundlePath)Frameworks\libswift*.dylib" />
+        <_SwiftLibsDevice Include="$(_AppBundlePath)Frameworks\libswift*.dylib">
+          <CodesignStampFile>$(DeviceSpecificOutputPath)OnDemandResources-codesign\$(_AppBundleName).app</CodesignStampFile>
+        </_SwiftLibsDevice>
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Fixes error when trying to build a release iPhone build

error : The "Codesign" task was not given a value for the required parameter "StampFile", nor was there a "CodesignStampFile" metadata on the resource *dylib